### PR TITLE
Add TagEngine tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -317,6 +317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,9 +498,12 @@ dependencies = [
  "axum",
  "config",
  "dashmap",
+ "futures",
  "opcua",
  "serde",
+ "serde_json",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]
@@ -1021,6 +1030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.26",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1061,35 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1205,6 +1252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1415,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1529,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1600,12 @@ dependencies = [
  "matches",
  "percent-encoding 1.0.1",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -1832,7 +1925,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive 0.8.26",
 ]
 
 [[package]]
@@ -1840,6 +1942,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/gateway_server/Cargo.toml
+++ b/gateway_server/Cargo.toml
@@ -15,3 +15,6 @@ dashmap = "5.5" # Concurrent HashMap
 opcua = "0.12" # OPC UA Client Library
 serde_json = "1.0"  # Added for JSON serialization in API endpoints
 tokio-tungstenite = "0.26.2"  # Added to resolve unresolved import in websocket.rs
+
+[dev-dependencies]
+futures = "0.3"

--- a/gateway_server/src/lib.rs
+++ b/gateway_server/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod drivers;
+pub mod tags;
+pub mod config;
+pub mod api;

--- a/gateway_server/src/main.rs
+++ b/gateway_server/src/main.rs
@@ -11,18 +11,14 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tokio::time::{interval, Duration, Instant};
-use config::settings::Settings;
-use tags::structures::{Tag, TagValue, TagMetadata, Quality};
-use tags::engine::TagEngine;
-use drivers::traits::{DeviceDriver, TagRequest};
-use drivers::opcua::OpcUaDriver;
+use gateway_server::config::settings::Settings;
+use gateway_server::tags::structures::{Tag, TagValue, TagMetadata, Quality};
+use gateway_server::tags::engine::TagEngine;
+use gateway_server::drivers::traits::{DeviceDriver, TagRequest};
+use gateway_server::drivers::opcua::OpcUaDriver;
 use serde_json::json;
 
-// Core Modules
-mod drivers;
-mod tags;
-mod config;
-mod api;
+// Modules are defined in the accompanying library crate (lib.rs)
 
 // Potentially other modules like scripting, historian, events etc.
 

--- a/gateway_server/src/tags/structures.rs
+++ b/gateway_server/src/tags/structures.rs
@@ -19,7 +19,7 @@ impl Default for Quality {
 }
 
 /// Represents the value, quality, and timestamp of a tag.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TagValue {
     pub value: ValueVariant,
     pub quality: Quality,

--- a/gateway_server/tests/tag_engine.rs
+++ b/gateway_server/tests/tag_engine.rs
@@ -1,0 +1,66 @@
+use gateway_server::tags::engine::TagEngine;
+use gateway_server::tags::structures::{Tag, TagValue, ValueVariant, TagMetadata, Quality};
+
+fn sample_tag(path: &str, driver_id: &str, address: &str) -> Tag {
+    Tag {
+        path: path.to_string(),
+        value: TagValue::new(ValueVariant::Int(0), Quality::Good),
+        driver_id: driver_id.to_string(),
+        driver_address: address.to_string(),
+        poll_rate_ms: 1000,
+        metadata: TagMetadata::default(),
+    }
+}
+
+#[test]
+fn register_and_read_tag() {
+    let engine = TagEngine::new();
+    let tag = sample_tag("Device/Tag1", "drv1", "addr1");
+    engine.register_tag(tag.clone());
+
+    let read = engine.read_tag("Device/Tag1").expect("tag should exist");
+    assert_eq!(read, tag.value);
+}
+
+#[test]
+fn update_tag_value() {
+    let engine = TagEngine::new();
+    let tag = sample_tag("Device/Tag2", "drv1", "addr2");
+    engine.register_tag(tag.clone());
+
+    let new_value = TagValue::new(ValueVariant::Int(42), Quality::Good);
+    let updated = engine.update_tag_value(&tag.path, new_value.clone());
+    assert!(updated);
+    let read = engine.read_tag(&tag.path).unwrap();
+    assert_eq!(read, new_value);
+}
+
+#[test]
+fn list_paths_and_find_by_address() {
+    let engine = TagEngine::new();
+    let tag1 = sample_tag("Device/TagA", "drv1", "a1");
+    let tag2 = sample_tag("Device/TagB", "drv1", "a2");
+    engine.register_tag(tag1.clone());
+    engine.register_tag(tag2.clone());
+
+    let mut paths = engine.get_all_tag_paths();
+    paths.sort();
+    assert_eq!(paths, vec![tag1.path.clone(), tag2.path.clone()]);
+
+    assert_eq!(engine.find_path_by_address("drv1", "a1"), Some(tag1.path));
+    assert_eq!(engine.find_path_by_address("drv1", "a2"), Some(tag2.path));
+}
+
+#[test]
+fn get_tag_details_and_all_tags() {
+    let engine = TagEngine::new();
+    let tag = sample_tag("Device/TagC", "drv2", "addrC");
+    engine.register_tag(tag.clone());
+
+    let details = engine.get_tag_details(&tag.path).expect("details");
+    assert_eq!(details.driver_id, tag.driver_id);
+
+    let all = futures::executor::block_on(engine.get_all_tags());
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].path, tag.path);
+}


### PR DESCRIPTION
## Summary
- expose modules via new library crate for testing
- update TagValue to derive `PartialEq`
- create integration tests for `TagEngine`
- add futures dev-dependency for tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688c387619c0832da5be5617e27f93cb