### PR TITLE
Add CI workflow to run cargo tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run tests
+        run: cargo test --workspace --all-targets --verbose


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs Rust and runs `cargo test`

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_688c3dcb7470832daf2185b7f758ee22