### PR TITLE
Add default config file and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,20 +129,26 @@ When deployed at the edge, the runtime leverages the core components for:
    git clone https://github.com/your-org/forgeio.git  # or openforge
    cd forgeio
    ```
-3. **Build & run**
+3. **Configure the gateway**
+
+   A sample `config.toml` is included at the repository root. It defines a dummy
+   OPC UA device and a few example tags. Adjust the settings or replace the file
+   with your own configuration before starting the server.
+
+4. **Build & run**
 
    ```bash
    cargo build
    cargo run --bin gateway_server
    ```
-4. **Launch the design environment**
+5. **Launch the design environment**
 
    ```bash
    cd frontend_design_env
    wasm-pack build
    ```
 
-5. **Run the Admin Dashboard (React/TypeScript)**
+6. **Run the Admin Dashboard (React/TypeScript)**
 
    ```bash
    cd webui

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,26 @@
+# Example configuration for the ForgeIO Gateway Server
+# This file defines device drivers and the tags to poll from them.
+
+[[devices]]
+id = "opcua1"
+name = "Dummy OPC UA"
+address = "opc.tcp://localhost:4840/freeopcua/server/"
+scan_rate_ms = 1000
+
+[[tags]]
+path = "Dummy/Temperature"
+driver_id = "opcua1"
+address = "ns=2;s=Temperature"
+poll_rate_ms = 1000
+
+[[tags]]
+path = "Dummy/Pressure"
+driver_id = "opcua1"
+address = "ns=2;s=Pressure"
+poll_rate_ms = 1000
+
+[[tags]]
+path = "Dummy/Counter"
+driver_id = "opcua1"
+address = "ns=2;s=Counter"
+poll_rate_ms = 1000


### PR DESCRIPTION
## Summary
- provide `config.toml` example so the gateway server can run
- document the config file in the README

## Testing
- `cargo test -p gateway_server --lib -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_688d4a0b0a90832dafc313f01dba76f0