### PR TITLE
Refactor OPC UA driver parsing and shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,8 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -839,6 +841,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +953,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1291,6 +1309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1403,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1559,7 +1595,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1569,6 +1617,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1666,6 +1740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1829,28 @@ checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/gateway_server/Cargo.toml
+++ b/gateway_server/Cargo.toml
@@ -16,6 +16,8 @@ opcua = "0.12" # OPC UA Client Library
 serde_json = "1.0"  # Added for JSON serialization in API endpoints
 tokio-tungstenite = "0.26.2"  # Added to resolve unresolved import in websocket.rs
 tower-http = { version = "0.5", features = ["fs", "auth"] } # Static file serving and auth middleware
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/gateway_server/src/api/rest.rs
+++ b/gateway_server/src/api/rest.rs
@@ -1,6 +1,8 @@
 // Placeholder for REST API implementation
 
+use tracing::info;
+
 pub fn init_routes() {
     // TODO: Implement REST routes using Axum
-    println!("REST API routes not implemented yet.");
+    info!("REST API routes not implemented yet.");
 }

--- a/gateway_server/src/api/websocket.rs
+++ b/gateway_server/src/api/websocket.rs
@@ -1,9 +1,8 @@
 // Placeholder for WebSocket handling
 
-use tokio::net::TcpListener;
-use tokio_tungstenite::accept_async;
+use tracing::info;
 
 pub async fn start_websocket_server() {
     // TODO: Implement WebSocket server
-    println!("WebSocket server not implemented yet.");
+    info!("WebSocket server not implemented yet.");
 }

--- a/gateway_server/src/drivers/traits.rs
+++ b/gateway_server/src/drivers/traits.rs
@@ -42,23 +42,23 @@ pub trait DeviceDriver: Send + Sync {
     fn config(&self) -> &DriverConfig;
 
     /// Connect to the underlying device.
-    fn connect(&mut self) -> DriverResult<()>;
+    async fn connect(&self) -> DriverResult<()>;
 
     /// Disconnect from the underlying device.
-    fn disconnect(&mut self) -> DriverResult<()>;
+    async fn disconnect(&self) -> DriverResult<()>;
 
     /// Check the connection status.
-    async fn check_status(&mut self) -> DriverResult<()>; // Returns Ok(()) if connected, Err otherwise
+    async fn check_status(&self) -> DriverResult<()>; // Returns Ok(()) if connected, Err otherwise
 
     /// Read a batch of tags.
     /// Takes a list of tag addresses and returns a map of address to TagValue.
-    async fn read_tags(&mut self, tags: &[TagRequest]) -> DriverResult<HashMap<String, TagValue>>;
+    async fn read_tags(&self, tags: &[TagRequest]) -> DriverResult<HashMap<String, TagValue>>;
 
     /// Write a batch of tags.
     /// Takes a map of tag address to the TagValue to write.
     /// Returns a map of address to TagValue representing the result (e.g., success or error status per tag).
     async fn write_tags(
-        &mut self,
+        &self,
         tags: HashMap<String, TagValue>,
     ) -> DriverResult<HashMap<String, TagValue>>;
 

--- a/gateway_server/src/lib.rs
+++ b/gateway_server/src/lib.rs
@@ -2,3 +2,4 @@ pub mod drivers;
 pub mod tags;
 pub mod config;
 pub mod api;
+pub mod logging;

--- a/gateway_server/src/logging.rs
+++ b/gateway_server/src/logging.rs
@@ -1,0 +1,31 @@
+use std::io::{self, Write};
+use tokio::sync::mpsc::UnboundedSender;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+struct ChannelWriter {
+    tx: UnboundedSender<String>,
+}
+
+impl Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let s = String::from_utf8_lossy(buf).to_string();
+        let _ = self.tx.send(s);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Initialize logging. If a channel is provided, log output is forwarded
+/// to the channel instead of standard output.
+pub fn init_logging(forward: Option<UnboundedSender<String>>) {
+    if let Some(tx) = forward {
+        let layer = fmt::layer().with_writer(move || ChannelWriter { tx: tx.clone() });
+        tracing_subscriber::registry().with(layer).init();
+    } else {
+        tracing_subscriber::fmt::init();
+    }
+}
+

--- a/gateway_server/src/main.rs
+++ b/gateway_server/src/main.rs
@@ -4,15 +4,16 @@ use gateway_server::drivers::opcua::OpcUaDriver;
 use gateway_server::drivers::traits::{DeviceDriver, TagRequest};
 use gateway_server::tags::engine::TagEngine;
 use gateway_server::tags::structures::{Quality, Tag, TagMetadata, TagValue};
+use gateway_server::logging::init_logging;
 use serde_json::json;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tokio::time::{interval, Duration, Instant};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::validate_request::ValidateRequestHeaderLayer;
+use tracing::{error, info, warn};
 
 // Modules are defined in the accompanying library crate (lib.rs)
 
@@ -20,21 +21,22 @@ use tower_http::validate_request::ValidateRequestHeaderLayer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("ForgeIO Gateway Server starting...");
+    init_logging(None);
+    info!("ForgeIO Gateway Server starting...");
 
     // --- Load Configuration ---
     let config_path = Path::new("config.toml");
     let settings = match Settings::load(config_path) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
+            error!(
                 "FATAL: Failed to load configuration from {:?}: {}",
                 config_path, e
             );
             std::process::exit(1);
         }
     };
-    println!(
+    info!(
         "Configuration loaded: {} devices, {} tags",
         settings.devices.len(),
         settings.tags.len()
@@ -43,42 +45,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- Initialize Tag Engine ---
     let tag_engine = TagEngine::new();
     let tag_engine_arc = Arc::new(tag_engine); // Wrap in Arc for sharing
-    println!("Tag Engine initialized.");
+    info!("Tag Engine initialized.");
 
     // --- Initialize Drivers ---
     // Store drivers in a thread-safe way, accessible by ID
-    let mut driver_instances: HashMap<String, Arc<Mutex<dyn DeviceDriver + Send + Sync>>> =
-        HashMap::new();
+    let mut driver_instances: HashMap<String, Arc<dyn DeviceDriver + Send + Sync>> = HashMap::new();
 
     for driver_config in settings.devices {
-        println!(
+        info!(
             "Initializing driver: {} ({})",
             driver_config.name, driver_config.id
         );
 
         // TODO: Add a 'driver_type' field to DriverConfig to select the correct driver
         // For now, assume all are OPC UA if opcua driver exists
-        let driver: Arc<Mutex<dyn DeviceDriver + Send + Sync>> = {
-            // Create the specific driver instance
-            let mut opcua_driver = OpcUaDriver::new(driver_config.clone())
-                .map_err(|e| format!("Failed to create OPC UA driver: {}", e))?;
-            // Attempt to connect
-            opcua_driver
+        let driver: Arc<dyn DeviceDriver + Send + Sync> = {
+            let driver = Arc::new(
+                OpcUaDriver::new(driver_config.clone())
+                    .map_err(|e| format!("Failed to create OPC UA driver: {}", e))?,
+            );
+            driver
                 .connect()
+                .await
                 .map_err(|e| format!("Failed to connect OPC UA driver: {}", e))?;
-            Arc::new(Mutex::new(opcua_driver)) // Wrap in Arc<Mutex>
+            driver
         };
 
         driver_instances.insert(driver_config.id.clone(), driver);
     }
     let drivers_arc = Arc::new(driver_instances); // Share the driver map
-    println!("{} drivers initialized and connected.", drivers_arc.len());
+    info!("{} drivers initialized and connected.", drivers_arc.len());
 
     // --- Register Tags ---
     for tag_config in settings.tags {
         // Check if the driver for this tag exists and was initialized
         if drivers_arc.contains_key(&tag_config.driver_id) {
-            println!(
+            info!(
                 "Registering tag: {} (Driver: {}, Address: {}, Rate: {}ms)",
                 tag_config.path, tag_config.driver_id, tag_config.address, tag_config.poll_rate_ms
             );
@@ -101,18 +103,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             tag_engine_arc.register_tag(initial_tag);
         } else {
-            eprintln!("WARN: Skipping tag '{}' because its driver '{}' was not found or failed to initialize.",
+            warn!("Skipping tag '{}' because its driver '{}' was not found or failed to initialize.",
                 tag_config.path, tag_config.driver_id);
         }
     }
-    println!("Tags registered in Tag Engine.");
+    info!("Tags registered in Tag Engine.");
 
     // --- Start Polling Loop ---
     let polling_tag_engine = Arc::clone(&tag_engine_arc);
     let polling_drivers = Arc::clone(&drivers_arc);
 
     tokio::spawn(async move {
-        println!("Polling task started.");
+        info!("Polling task started.");
         // Group tags by (driver_id, poll_rate_ms)
         let mut poll_groups: HashMap<(String, u64), Vec<String>> = HashMap::new();
         for tag_path in polling_tag_engine.get_all_tag_paths() {
@@ -128,7 +130,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .push(tag_path);
             }
         }
-        println!("Polling groups created: {}", poll_groups.len());
+        info!("Polling groups created: {}", poll_groups.len());
 
         // Store last poll time for each group
         let mut last_poll_times: HashMap<(String, u64), Instant> = HashMap::new();
@@ -147,14 +149,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 if now.duration_since(*last_poll) >= poll_duration {
                     // This group is due for polling
-                    println!(
+                    info!(
                         "Polling group: Driver '{}', Rate {}ms, Tags: {}",
                         driver_id,
                         poll_rate_ms,
                         tag_paths.len()
                     );
 
-                    if let Some(driver_mutex) = polling_drivers.get(driver_id) {
+                    if let Some(driver) = polling_drivers.get(driver_id) {
                         let mut requests = Vec::new();
                         // Need tag address again - requires TagEngine modification or storing more info
                         for path in tag_paths {
@@ -167,10 +169,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
 
                         if !requests.is_empty() {
-                            let mut driver = driver_mutex.lock().await; // Lock the driver for the read call
                             match driver.read_tags(&requests).await {
                                 Ok(results) => {
-                                    println!(
+                                    info!(
                                         "Read successful for {} tags from driver '{}'",
                                         results.len(),
                                         driver_id
@@ -187,8 +188,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 }
                                 Err(e) => {
-                                    eprintln!(
-                                        "ERROR: Failed to read tags from driver '{}': {}",
+                                    error!(
+                                        "Failed to read tags from driver '{}': {}",
                                         driver_id, e
                                     );
                                     // Optionally mark tags as Bad quality
@@ -200,7 +201,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
                         }
                     } else {
-                        eprintln!("WARN: Driver '{}' not found for polling.", driver_id);
+                        warn!("Driver '{}' not found for polling.", driver_id);
                         // Mark tags as Bad?
                     }
                     // Update last poll time regardless of success/failure to avoid spamming logs on error
@@ -211,7 +212,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // --- Start API Server ---
-    println!("Starting API server...");
+    info!("Starting API server...");
     let app = Router::new()
         .route("/api/health", get(root))
         .route("/tags", get(get_tags)) // New route for tags
@@ -223,7 +224,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(ValidateRequestHeaderLayer::basic("admin", "admin"));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    println!("API server listening on {}", addr);
+    info!("API server listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;


### PR DESCRIPTION
## Summary
- parse OPC UA node ids using the library's `FromStr` implementation
- disconnect sessions on a blocking thread to avoid runtime shutdown issues
- add integration test exercising connection and tag reads (ignored for now)
- add a flexible logging module and use structured logs across the server and OPC UA driver
- perform OPC UA connection inside a blocking section to avoid runtime shutdown panics

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688d956c5bbc832db05f53b517d2527d