### PR TITLE
feat: add stats endpoint and admin UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ When deployed at the edge, the runtime leverages the core components for:
    npm run build
    ```
 
+7. **Run Gateway and Admin UI Together**
+
+   ```bash
+   ./run_gateway_and_admin.sh
+   ```
+
 The gateway API now requires HTTP Basic auth with the default credentials
 `admin`/`admin`.
 

--- a/run_gateway_and_admin.sh
+++ b/run_gateway_and_admin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Start the gateway server
+(cd gateway_server && cargo run) &
+SERVER_PID=$!
+
+# Start the admin web UI
+(cd webui && npm run dev) &
+WEB_PID=$!
+
+trap "kill $SERVER_PID $WEB_PID" EXIT
+
+wait $SERVER_PID $WEB_PID
+

--- a/webui/src/Dashboard.tsx
+++ b/webui/src/Dashboard.tsx
@@ -1,16 +1,33 @@
 import { useEffect, useState } from 'react'
 
+interface Stats {
+  uptime_seconds: number
+  tag_count: number
+  driver_count: number
+}
+
 export default function Dashboard() {
   const [health, setHealth] = useState<string>('')
+  const [stats, setStats] = useState<Stats | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  const headers = { Authorization: 'Basic ' + btoa('admin:admin') }
+
   useEffect(() => {
-    fetch('/api/health')
+    fetch('/api/health', { headers })
       .then(res => {
         if (!res.ok) throw new Error('Failed to fetch health status')
         return res.text()
       })
       .then(setHealth)
+      .catch(err => setError(err.message))
+
+    fetch('/api/stats', { headers })
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch stats')
+        return res.json()
+      })
+      .then(data => setStats(data as Stats))
       .catch(err => setError(err.message))
   }, [])
 
@@ -19,6 +36,13 @@ export default function Dashboard() {
       <h1>Admin Dashboard</h1>
       {error && <p className="error">{error}</p>}
       {health && <p>{health}</p>}
+      {stats && (
+        <ul>
+          <li>Uptime: {stats.uptime_seconds}s</li>
+          <li>Drivers: {stats.driver_count}</li>
+          <li>Tags: {stats.tag_count}</li>
+        </ul>
+      )}
     </div>
   )
 }

--- a/webui/src/TagsPage.tsx
+++ b/webui/src/TagsPage.tsx
@@ -13,8 +13,10 @@ export default function TagsPage() {
   const [tags, setTags] = useState<any[]>([])
   const [error, setError] = useState<string | null>(null)
 
+  const headers = { Authorization: 'Basic ' + btoa('admin:admin') }
+
   useEffect(() => {
-    fetch('/tags')
+    fetch('/tags', { headers })
       .then(res => {
         if (!res.ok) throw new Error('Failed to fetch tags')
         return res.json()


### PR DESCRIPTION
## Summary
- add shared app state and stats API to gateway server
- secure admin UI requests with basic auth and surface runtime stats
- add helper script to run gateway server and admin UI together

## Testing
- `cargo test`
- `npm run lint` *(fails: Parsing error: The keyword 'interface' is reserved)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e74495090832d8019437906c53bf1